### PR TITLE
Remove unused register_iboost() to fix build

### DIFF
--- a/esphome/components/iboost/iboost.cpp
+++ b/esphome/components/iboost/iboost.cpp
@@ -47,8 +47,7 @@ SOFTWARE.
 namespace esphome {
     namespace iboost {
 
-        // Global instance
-        iBoost * global_iboost = nullptr;
+
 
         enum { // codes for the various requests and responses
             SAVED_TODAY = 0xCA,
@@ -97,12 +96,6 @@ namespace esphome {
         char pbuf[32];
         byte boostTime;
         bool waterHeating, cylinderHot, batteryLow, overheat;
-
-        // Register component
-        void register_iboost() {
-            global_iboost = new iBoost();
-            App.register_component(global_iboost);
-        }
 
         void iBoost::setup() {
             // Initialize text sensors

--- a/esphome/components/iboost/iboost.h
+++ b/esphome/components/iboost/iboost.h
@@ -139,7 +139,6 @@ private:
 
 
 };
-extern iBoost *global_iboost;  // Declare global instance of iBoost
 }  // namespace iboost
 }  // namespace esphome
 #endif


### PR DESCRIPTION
  ## Summary
  - Removed `register_iboost()` which called the protected
    `Application::register_component_()`, causing a build failure
    on ESPHome 2026.3.0
  - Removed the associated unused `global_iboost` variable

  Component registration is already handled by ESPHome's codegen via
  `cg.register_component()` in `sensor.py`, so this was dead code.

  ## Test plan
  - Verified the project compiles successfully against ESPHome 2026.3.0