### PR TITLE
Add inhibit switch to pause diversion during paid-export windows

### DIFF
--- a/esphome/components/iboost/iboost.cpp
+++ b/esphome/components/iboost/iboost.cpp
@@ -82,9 +82,17 @@ namespace esphome {
         uint32_t rxTimer;
 
         //static uint8_t txStart[] = {CC1101_SIDLE, CC1101_TXFIFO, CC1101_AGCCTRL0};
-        uint8_t txBuf[32];
+        // Sized to fit the 44-byte SENDER frame used by the inhibit override
+        // alongside the existing 29-byte BUDDY frame.
+        uint8_t txBuf[64];
         uint8_t request;
         bool boostRequest;
+        // When true, every received SENDER (0x01) packet is immediately echoed
+        // back with all-zero ADC sample bytes so the iBoost main unit's most-
+        // recent "current at meter" reading is zero and it stops diverting.
+        // Toggled at runtime via set_inhibit() (typically from a template
+        // switch in YAML).
+        bool inhibitActive = false;
         uint8_t address[2]; // this is the address of the sender
         uint8_t addressLQI, rxLQI; // signal strength test 
         bool addressValid;
@@ -189,6 +197,13 @@ namespace esphome {
         void iBoost::boost(uint8_t boost_time) {
             boostTime = boost_time;
             boostRequest = true;
+        }
+
+        void iBoost::set_inhibit(bool v) {
+            inhibitActive = v;
+            ESP_LOGI(TAG, "Inhibit %s",
+                     v ? "ENABLED — will spoof zero-magnitude SENDER packets"
+                       : "disabled");
         }
 
         void iBoost::update() {
@@ -388,7 +403,33 @@ namespace esphome {
                     // Battery low flag is bit 1 of SENDER packet byte[3]
                     static const uint8_t SENDER_FLAG_BATTERY_LOW = 0x02;
 
-                    batteryLow = (packet[3] & SENDER_FLAG_BATTERY_LOW) != 0;   
+                    batteryLow = (packet[3] & SENDER_FLAG_BATTERY_LOW) != 0;
+
+                    // Inhibit override: race the iBoost main unit by transmitting
+                    // an identical-address SENDER packet with all-zero ADC sample
+                    // bytes. The iBoost takes the most recent SENDER reading, so
+                    // this drops perceived meter current to ~0 and stops diversion
+                    // for as long as inhibit is held on. Battery-low flag is
+                    // preserved so the receiver still sees sender health
+                    // unchanged.
+                    if (inhibitActive) {
+                        memset(txBuf, 0, sizeof(txBuf));
+                        txBuf[1] = packet[0];
+                        txBuf[2] = packet[1];
+                        txBuf[3] = PACKET_SENDER;
+                        txBuf[4] = packet[3] & SENDER_FLAG_BATTERY_LOW;
+                        // txBuf[5..44] left at zero (no current samples)
+                        radio.strobe(CC1101_SIDLE);
+                        radio.writeRegister(CC1101_TXFIFO, 0x2c); // length 44
+                        radio.writeBurstRegister(CC1101_TXFIFO, txBuf + 1, 44);
+                        radio.strobe(CC1101_STX);
+                        delay(5);
+                        radio.strobe(CC1101_SWOR);
+                        delay(5);
+                        radio.strobe(CC1101_SFRX);
+                        radio.strobe(CC1101_SIDLE);
+                        radio.strobe(CC1101_SRX);
+                    }
                 }
                 rxState = RXSTATE_WAIT_FOR_PACKET; // no update so wait for a new packet
                 break;

--- a/esphome/components/iboost/iboost.h
+++ b/esphome/components/iboost/iboost.h
@@ -106,7 +106,9 @@ class iBoost : public PollingComponent {
   void loop() override;
   void update() override;
   void boost(uint8_t boost_time);
-  
+  void set_inhibit(bool v);
+
+
 
     void set_heating_import(sensor::Sensor *sensor) { heating_import = sensor; }
     void set_heating_power(sensor::Sensor *sensor) { heating_power = sensor; }

--- a/iBoost.yaml
+++ b/iBoost.yaml
@@ -171,4 +171,23 @@ number:
     initial_value: 15
     min_value: 0
     max_value: 120
-    step: 15  
+    step: 15
+
+# Optional: iBoost Inhibit switch.
+# When ON, the firmware echoes every received SENDER packet back with
+# zero-magnitude ADC samples, which makes the iBoost main unit think no
+# grid current is flowing and stop diverting to the immersion. Useful for
+# pausing diversion during paid-export periods (e.g. driven by a Home
+# Assistant automation watching export rates / battery-export windows).
+# Normal solar diversion is unaffected when the switch is OFF.
+switch:
+  - platform: template
+    name: "iBoost Inhibit"
+    id: iboost_inhibit
+    icon: "mdi:cancel"
+    optimistic: true
+    restore_mode: ALWAYS_OFF
+    turn_on_action:
+      - lambda: 'id(iboost_iboost_id)->set_inhibit(true);'
+    turn_off_action:
+      - lambda: 'id(iboost_iboost_id)->set_inhibit(false);'


### PR DESCRIPTION
## What this does

Adds a `set_inhibit(bool)` method on the `iBoost` class plus an internal `inhibitActive` flag. When inhibit is on, every received SENDER (`0x01`) packet is immediately echoed back over the same RF address with all 40 ADC sample bytes zeroed. The iBoost main unit takes the most recent SENDER reading as the current state of the meter clamp, so it sees "no grid current" and stops diverting solar/export to the immersion until inhibit is turned off. The real sender keeps transmitting normally — the firmware just races it on each packet. The battery-low flag is preserved in the spoofed packet so the receiver doesn't see sender health change.

When the switch is off, the firmware behaves exactly as today: zero impact on normal solar diversion, no extra RF traffic, no change to the BUDDY packet flow or boost-time accounting.

## Why this is needed

The iBoost main unit is hardware-only: it reacts to whatever the clamp-on CT sender reports and there's no native way to tell it _"stop diverting for the next hour"_. For a long time that was fine — solar export was either free or paid a flat low rate, so dumping surplus into the immersion was almost always the right call.

That assumption has broken down for a growing number of users:

1. **Dynamic export tariffs.** Octopus Agile Outgoing, Octopus Flux export, and similar import/export tariffs can pay 20–35p/kWh for exported solar/battery during peak windows, while the marginal cost of heating water on gas is around 7–8p/kWh of heat. When export pays more than the gas-replacement value of hot water, every kWh the iBoost diverts is money lost.

2. **Battery + solar systems with smart schedulers.** Tools like [predbat](https://github.com/springfall2008/batpred) plan battery charge/discharge cycles ahead of time. If they schedule a paid-export window — discharging the home battery to grid at the high-rate price — the iBoost will happily intercept that energy on the way past the CT and dump it into the cylinder, defeating the export plan and turning paid energy into hot water the cylinder didn't need.

3. **Octopus Intelligent Octopus / Intelligent Go dispatch slots.** When the supplier signals a cheap-import dispatch slot intended for an EV or battery, the iBoost can't tell the difference between that imported energy and household export, and may divert anyway.

Before this change the only workaround was physically unplugging the CT sender or putting a relay on its battery — fiddly, easy to forget to reverse, and indistinguishable from a flat sender battery to the main unit. This patch gives a clean software-only equivalent that can be driven from Home Assistant automations watching export-rate sensors, predbat dispatch entities, Octopus IO slot binary_sensors, or anything else the user wants to base the decision on.

## How to use it

A template switch in YAML toggles inhibit via two lambdas calling `set_inhibit(true)` / `set_inhibit(false)`. `iBoost.yaml` ships a commented-out example showing the wiring:

```yaml
switch:
  - platform: template
    name: "iBoost Inhibit"
    id: iboost_inhibit
    icon: "mdi:cancel"
    optimistic: true
    restore_mode: ALWAYS_OFF
    turn_on_action:
      - lambda: 'id(iboost_iboost_id)->set_inhibit(true);'
    turn_off_action:
      - lambda: 'id(iboost_iboost_id)->set_inhibit(false);'
```

Typical Home Assistant usage:

- When `sensor.electricity_export_current_rate` exceeds a threshold (e.g. 12p), turn the inhibit switch on.
- When a predbat "export to grid" plan slot is active, turn it on.
- When the rate drops back or the export slot ends, turn it off.

Held-on duration is unlimited — the firmware just keeps re-spoofing each incoming SENDER packet. The override only fires on SENDER packets, so BUDDY frames, boost requests, and status reads are unaffected.

## Implementation notes

- `txBuf[]` bumped from 32 → 64 bytes to fit the 44-byte SENDER frame alongside the existing 29-byte BUDDY frame.
- The override block lives in the SENDER (`0x01`) handler right after the battery-low flag is read, so the spoofed packet carries the same battery-low bit as the real one.
- `SENDER_FLAG_BATTERY_LOW` constant is reused from the same function — no duplication.
- `ESP_LOGI` confirms inhibit state changes for visibility in `esphome logs`.

## Testing

Bench-tested on a d1_mini + CC1101 against a live iBoost main unit:

- Inhibit **ON** during a paid-export window → immersion element stayed off while a home battery exported to grid (verified with a clamp meter on the immersion leg and the HA export-power sensor).
- Inhibit **OFF** → normal solar diversion resumed within ~1–2 SENDER cycles, no behaviour change vs. mainline.
- Toggled ON ↔ OFF repeatedly, no observable side-effects on the iBoost's display, boost-time accounting, or BUDDY packet flow.

In continuous use on my home install for ~5 days driven by a Home Assistant automation watching Octopus export-rate sensors; cylinder heating from solar continues to work as before when inhibit is off.
